### PR TITLE
Reinsert `metadata()` function

### DIFF
--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -335,6 +335,26 @@ class IamDataFrame(object):
         elif not silent:
             logger().info('{} scenarios satisfy the criteria'.format(count))
 
+    def metadata(self, meta, name=None):
+        """Add metadata columns as pandas Series or DataFrame
+
+        Parameters
+        ----------
+        meta: pandas.DataFrame or pandas.Series
+            adds columns to the metadata, index must be `['model', 'scenario']`
+        name: str
+            category column name (if not given by data series/column name)
+        """
+        if isinstance(meta, pd.Series):
+            meta = meta.to_frame(meta.name or name)
+
+        diff = meta.index.difference(self.meta.index)
+        if not diff.empty:
+            raise ValueError('adding metadata for non-existing scenarios {}!'
+                             .format(diff))
+
+        self.meta = meta.combine_first(self.meta)
+
     def categorize(self, name, value, criteria, filters={},
                    color=None, marker=None, linestyle=None):
         """Assign scenarios to a category according to specific criteria

--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -345,14 +345,16 @@ class IamDataFrame(object):
         name: str
             category column name (if not given by data series/column name)
         """
-        if isinstance(meta, pd.Series):
-            meta = meta.to_frame(meta.name or name)
+        if not meta.index.names == mod_scen:
+            raise ValueError("illegal index '{}'!".format(meta.index.names))
 
         diff = meta.index.difference(self.meta.index)
         if not diff.empty:
-            raise ValueError('adding metadata for non-existing scenarios {}!'
+            raise ValueError("adding metadata for non-existing scenarios '{}'!"
                              .format(diff))
 
+        if isinstance(meta, pd.Series):
+            meta = meta.to_frame(meta.name or name)
         self.meta = meta.combine_first(self.meta)
 
     def categorize(self, name, value, criteria, filters={},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -120,6 +120,38 @@ def test_load_metadata(test_ia):
     pd.testing.assert_series_equal(obs['category'], exp['category'])
 
 
+def test_add_metadata_as_df(test_ia):
+    dct = {'model': ['test_model'], 'scenario': ['test_scenario'],
+           'meta_values': [0.3]}
+    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])
+    test_ia.metadata(exp)
+    
+    obs = test_ia['meta_values']
+    pd.testing.assert_series_equal(obs['meta_values'], exp['meta_values']) 
+
+
+def test_add_metadata_as_series(test_ia):
+    idx = pd.MultiIndex(levels=[['test_model'], ['test_scenario']],
+                        labels=[[0], [0]], names=['model', 'scenario'])
+
+    s = pd.Series([0.4], idx)
+    test_ia.metadata(s, 'meta_series')
+
+    exp = s.to_frame('meta_series')
+    obs = test_ia['meta_series']
+    print(exp)
+    print(obs)
+    pd.testing.assert_frame_equal(obs, exp)
+
+
+def test_add_metadata_fail(test_ia):
+    idx = pd.MultiIndex(levels=[['test_model', 'fail_model'],
+                                ['test_scenario', 'fail_scenario']],
+                        labels=[[0, 1], [0, 1]], names=['model', 'scenario'])
+    s = pd.Series([0.4, 0.5], idx)
+    pytest.raises(ValueError, test_ia.metadata, s)
+
+
 def test_append():
     df = IamDataFrame(data=data_path)
     df2 = df.append(other=os.path.join(here, 'testing_data_2.csv'))


### PR DESCRIPTION
re-inserting the function to add metadata columns indexed over `[model, scenario]`, with three unit tests