### PR TITLE
Categorize by all not any

### DIFF
--- a/pyam_analysis/core.py
+++ b/pyam_analysis/core.py
@@ -225,7 +225,7 @@ class IamDataFrame(object):
             return  # EXIT FUNCTION
 
         # find all data that matches categorization
-        idx = _meta_idx(_apply_criteria(self.data, criteria, inclusive=True))
+        idx = _meta_idx(_apply_criteria(self.data, criteria, in_range=True))
 
         # update metadata dataframe
         if len(idx) == 0:
@@ -248,7 +248,7 @@ class IamDataFrame(object):
         exclude: bool, default False
             if true, exclude models and scenarios failing validation from further analysis
         """
-        df = _apply_criteria(self.data, criteria, inclusive=False)
+        df = _apply_criteria(self.data, criteria, in_range=False)
 
         if exclude:
             idx = _meta_idx(df)
@@ -395,15 +395,15 @@ def _apply_filters(data, meta, filters):
     return keep
 
 
-def _apply_criteria(df, criteria, inclusive=True):
+def _apply_criteria(df, criteria, in_range=True):
     idxs = []
     for var, check in criteria.items():
         fail_idx = []
         where_idx = []
         _df = df[df['variable'] == var]
         where_idx.append(set(_df.index))
-        up_op = _df['value'].__lt__ if inclusive else _df['value'].__gt__
-        lo_op = _df['value'].__gt__ if inclusive else _df['value'].__lt__
+        up_op = _df['value'].__le__ if in_range else _df['value'].__gt__
+        lo_op = _df['value'].__ge__ if in_range else _df['value'].__lt__
         for check_type, val in check.items():
             if check_type == 'up':
                 fail_idx.append(set(_df.index[up_op(val)]))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -126,12 +126,13 @@ def test_category_pass(test_df):
 
 
 def test_category_top_level(test_df):
-    dct = {'model': ['test_model'], 'scenario': ['test_scenario'],
-           'category': ['Testing']}
+    dct = {'model': ['test_model', 'test_model'],
+           'scenario': ['test_scenario', 'test_scenario2'],
+           'category': ['Testing', 'None']}
     exp = pd.DataFrame(dct).set_index(['model', 'scenario'])['category']
 
     categorize(test_df, 'category', 'Testing',
-               criteria={'Primary Energy': {'up': 10}},
+               criteria={'Primary Energy': {'up': 6}},
                filters={'variable': 'Primary Energy'})
     obs = test_df['category']
     pd.testing.assert_series_equal(obs, exp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -138,13 +138,14 @@ def test_category_top_level(test_df):
 
 
 def test_load_metadata(test_df):
+    dct = {'model': ['test_model'] * 2,
+           'scenario': ['test_scenario', 'test_scenario2'],
+           'category': ['imported', None]}
+    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])
+
     test_df.load_metadata(os.path.join(
         here, 'testing_metadata.xlsx'), sheet_name='metadata')
-
-    obs = test_df.meta
-    dct = {'model': ['test_model'], 'scenario': ['test_scenario'],
-           'category': ['imported']}
-    exp = pd.DataFrame(dct).set_index(['model', 'scenario'])
+    obs = test_df.meta    
     pd.testing.assert_series_equal(obs['category'], exp['category'])
 
 
@@ -153,11 +154,11 @@ def test_append():
     df2 = df.append(other=os.path.join(here, 'testing_data_2.csv'))
 
     obs = df['scenario'].unique()
-    exp = ['test_scenario']
+    exp = ['test_scenario', 'test_scenario2']
     npt.assert_array_equal(obs, exp)
 
     obs = df2['scenario'].unique()
-    exp = ['test_scenario', 'append_scenario']
+    exp = ['test_scenario', 'test_scenario2', 'append_scenario']
     npt.assert_array_equal(obs, exp)
 
 
@@ -169,8 +170,10 @@ def test_append_duplicates(test_df):
 def test_interpolate():
     df = IamDataFrame(data=data_path)
     df.interpolate(2007)
-    dct = {'model': ['test_model'] * 3, 'scenario': ['test_scenario'] * 3,
-           'years': [2005, 2007, 2010], 'value': [1, 3, 6]}
+    dct = {'model': ['test_model'] * 6, 
+           'scenario': ['test_scenario'] * 3 + ['test_scenario2'] * 3,
+           'years': [2005, 2007, 2010, 2005, 2007, 2010], 
+           'value': [1, 3, 6, 2, 4, 7]}
     exp = pd.DataFrame(dct).pivot_table(index=['model', 'scenario'],
                                         columns=['years'], values='value')
     obs = df.filter({'variable': 'Primary Energy'}).timeseries()

--- a/tests/testing_data.csv
+++ b/tests/testing_data.csv
@@ -1,3 +1,4 @@
 model,scenario,region,variable,unit,2005,2010
 test_model,test_scenario,World,Primary Energy,EJ/y,1,6
 test_model,test_scenario,World,Primary Energy|Coal,EJ/y,0.5,3
+test_model,test_scenario2,World,Primary Energy,EJ/y,2,7

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -9,7 +9,7 @@ plot_path = os.path.join(here, 'plot_data.csv')
 IMAGE_BASELINE_DIR = os.path.join(here, 'expected_figs')
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def test_df():
     df = IamDataFrame(data=data_path)
     yield df


### PR DESCRIPTION
Illustration of one major break from the previous implementation, which only became apparent when I extended the unit-test data to implement checks for the refactored `metadata()` feature.

In the previous implementation, using `validate()` over a multi-year timeseries failed if *any* at least one value was outside of the bounds, while `categorize()` only passes (assign the category) if *all* values are within the range (i.e., the `max()` satisfies an upper bound rather than the `min()`) . Currently, `categorize()` assigns a category according to the minimum of an upper bound.

Also, I'd think that the range checks should be implemented as upper/lower-or-equal for the inclusive option.

This PR:
 - extends the unit test dataset, adapt all unit tests to pass
 - illustrate that the `validate()` function does not behave as expected (unit tests fail)
 - change behaviour of `_apply_criteria()` function to use more lenient checks