### PR TITLE
Pd to pyam cleanup

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1540,7 +1540,6 @@ def df_to_pyam(df, **kwargs):
     for col in cols:
         _df = df[col].to_frame().rename(columns={col: 'value'})
         _df['variable'] = col
-        dfs.append(_df.reset_index())
-    df = pd.concat(dfs)
-    df = _apply_defaults(df, defaults)
+        dfs.append(_df)
+    df = _apply_defaults(pd.concat(dfs).reset_index(), defaults)
     return IamDataFrame(_apply_defaults(df, defaults))

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -1501,16 +1501,13 @@ def compare(left, right, left_label='left', right_label='right',
 
 def concat(dfs):
     """Concatenate a series of `pyam.IamDataFrame`-like objects together"""
-    if not hasattr(dfs, '__iter__'):
+    if isstr(dfs) or not hasattr(dfs, '__iter__'):
         raise TypeError('Input data must be iterable (e.g., list or tuple)')
 
     _df = None
     for df in dfs:
         if not isinstance(df, IamDataFrame):
-            try:
-                df = IamDataFrame(df)
-            except:
-                raise TypeError('Could not cast {} to IamDataFrame'.format(df))
+            df = IamDataFrame(df)
         if _df is None:
             _df = copy.deepcopy(df)
         else:

--- a/pyam/core.py
+++ b/pyam/core.py
@@ -23,6 +23,7 @@ from pyam.utils import (
     read_files,
     read_pandas,
     format_data,
+    sort_data,
     to_int,
     find_depth,
     pattern_match,
@@ -224,15 +225,14 @@ class IamDataFrame(object):
             ret.meta = ret.meta.append(other.meta.loc[diff, :], **sort_kwarg)
 
         # append other.data (verify integrity for no duplicates)
-        ret.data.set_index(ret._LONG_IDX, inplace=True)
-        _other = other.data.set_index(other._LONG_IDX)
-        ret.data = ret.data.append(_other, verify_integrity=True)\
-            .reset_index(drop=False)
+        _data = ret.data.set_index(ret._LONG_IDX).append(
+            other.data.set_index(other._LONG_IDX), verify_integrity=True)
 
         # merge extra columns in `data` and set `LONG_IDX`
         ret.extra_cols += [i for i in other.extra_cols
                            if i not in ret.extra_cols]
         ret._LONG_IDX = IAMC_IDX + [ret.time_col] + ret.extra_cols
+        ret.data = sort_data(_data.reset_index(), ret._LONG_IDX)
 
         if not inplace:
             return ret

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -194,10 +194,13 @@ def format_data(df):
     # cast value columns to numeric, drop NaN's, sort data
     df['value'] = df['value'].astype('float64')
     df.dropna(inplace=True)
-    df.sort_values(META_IDX + ['variable', time_col, 'region'] + extra_cols,
-                   inplace=True)
 
-    return df, time_col, extra_cols
+    # check for duplicates and return sorted data
+    idx_cols = META_IDX + ['variable', time_col, 'region'] + extra_cols
+    if any(df[idx_cols].duplicated()):
+        raise ValueError('duplicate rows in `data`!')
+
+    return df.sort_values(idx_cols), time_col, extra_cols
 
 
 def style_df(df, style='heatmap'):

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -398,5 +398,6 @@ def to_int(x, index=False):
 
 
 def concat_with_pipe(x, cols=None):
-    """Concatenate elements from `pd.Series` separated by `|`, drop `None`"""
-    return '|'.join([str(x[i]) for i in cols or x.index if x[i] is not None])
+    """Concatenate a `pd.Series` separated by `|`, drop `None` or `np.nan`"""
+    return '|'.join([x[i] for i in cols or x.index
+                     if x[i] is not None and x[i] is not np.nan])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -398,5 +398,5 @@ def to_int(x, index=False):
 
 
 def concat_with_pipe(x, cols=None):
-    """Concatenate elements from `pd.Series` separated by `|`"""
-    return '|'.join([x[i] for i in cols or x.index if x[i] is not None])
+    """Concatenate elements from `pd.Series` separated by `|`, drop `None`"""
+    return '|'.join([str(x[i]) for i in cols or x.index if x[i] is not None])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -401,3 +401,10 @@ def concat_with_pipe(x, cols=None):
     """Concatenate a `pd.Series` separated by `|`, drop `None` or `np.nan`"""
     return '|'.join([x[i] for i in cols or x.index
                      if x[i] is not None and x[i] is not np.nan])
+
+
+def reduce_hierarchy(x, depth):
+    """Reduce the hierarchy (depth by `|`) string to the specified level"""
+    _x = x.split('|')
+    depth = len(_x) + depth - 1 if depth < 0 else depth
+    return '|'.join(_x[0:(depth + 1)])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -395,3 +395,8 @@ def to_int(x, index=False):
         return x
     else:
         return _x
+
+
+def concat_with_pipe(x, cols=None):
+    """Concatenate elements from `pd.Series` separated by `|`"""
+    return '|'.join([x[i] for i in cols or x.index if x[i] is not None])

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -203,14 +203,6 @@ def format_data(df):
     return df.sort_values(idx_cols), time_col, extra_cols
 
 
-def style_df(df, style='heatmap'):
-    if style == 'highlight_not_max':
-        return df.style.apply(lambda s: ['' if v else 'background-color: yellow' for v in s == s.max()])
-    if style == 'heatmap':
-        cm = sns.light_palette("green", as_cmap=True)
-        return df.style.background_gradient(cmap=cm)
-
-
 def find_depth(data, s='', level=None):
     """
     return or assert the depth (number of `|`) of variables

--- a/pyam/utils.py
+++ b/pyam/utils.py
@@ -196,11 +196,16 @@ def format_data(df):
     df.dropna(inplace=True)
 
     # check for duplicates and return sorted data
-    idx_cols = META_IDX + ['variable', time_col, 'region'] + extra_cols
+    idx_cols = IAMC_IDX + [time_col] + extra_cols
     if any(df[idx_cols].duplicated()):
         raise ValueError('duplicate rows in `data`!')
 
-    return df.sort_values(idx_cols), time_col, extra_cols
+    return sort_data(df, idx_cols), time_col, extra_cols
+
+
+def sort_data(data, cols):
+    """Sort `data` rows and order columns"""
+    return data.sort_values(cols)[cols + ['value']].reset_index(drop=True)
 
 
 def find_depth(data, s='', level=None):

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -1,10 +1,5 @@
-import copy
-import pytest
-
-import numpy as np
 import pandas as pd
-
-from pyam import IamDataFrame, compare, df_to_pyam
+from pyam import compare, df_to_pyam
 
 
 def test_cast_from_value_col(meta_df):
@@ -16,11 +11,8 @@ def test_cast_from_value_col(meta_df):
     ],
         columns=['model', 'scenario', 'region', 'unit', 'year',
                  'Primary Energy', 'Primary Energy|Coal'],
-    )    
+    )
     df = df_to_pyam(df_with_value_cols)
-
-    print(df.timeseries())
-    print(meta_df.timeseries())
 
     assert compare(meta_df, df).empty
     pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_cast_to_iamc.py
+++ b/tests/test_cast_to_iamc.py
@@ -1,0 +1,26 @@
+import copy
+import pytest
+
+import numpy as np
+import pandas as pd
+
+from pyam import IamDataFrame, compare, df_to_pyam
+
+
+def test_cast_from_value_col(meta_df):
+    df_with_value_cols = pd.DataFrame([
+        ['model_a', 'scen_a', 'World', 'EJ/y', 2005, 1, 0.5],
+        ['model_a', 'scen_a', 'World', 'EJ/y', 2010, 6., 3],
+        ['model_a', 'scen_b', 'World', 'EJ/y', 2005, 2, None],
+        ['model_a', 'scen_b', 'World', 'EJ/y', 2010, 7, None]
+    ],
+        columns=['model', 'scenario', 'region', 'unit', 'year',
+                 'Primary Energy', 'Primary Energy|Coal'],
+    )    
+    df = df_to_pyam(df_with_value_cols)
+
+    print(df.timeseries())
+    print(meta_df.timeseries())
+
+    assert compare(meta_df, df).empty
+    pd.testing.assert_frame_equal(df.data, meta_df.data)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,12 @@ def test_init_df_with_float_cols_raises(test_pd_df):
     pytest.raises(ValueError, IamDataFrame, data=_test_df)
 
 
+def test_init_df_with_duplicates_raises(test_df):
+    _df = test_df.timeseries()
+    _df = _df.append(_df.iloc[0]).reset_index()
+    pytest.raises(ValueError, IamDataFrame, data=_df)
+
+
 def test_init_df_with_float_cols(test_pd_df):
     _test_df = test_pd_df.rename(columns={2005: 2005., 2010: 2010.})
     obs = IamDataFrame(_test_df).timeseries().reset_index()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ import pandas as pd
 from numpy import testing as npt
 
 from pyam import IamDataFrame, validate, categorize, \
-    require_variable, filter_by_meta, META_IDX, IAMC_IDX
+    require_variable, filter_by_meta, META_IDX, IAMC_IDX, sort_data
 from pyam.core import _meta_idx, concat
 
 from conftest import TEST_DATA_DIR
@@ -778,7 +778,7 @@ def test_filter_by_int(meta_df):
 def _r5_regions_exp(df):
     df = df.filter(region='World', keep=False)
     df['region'] = 'R5MAF'
-    return df.data.reset_index(drop=True)
+    return sort_data(df.data, df._LONG_IDX)
 
 
 def test_map_regions_r5(reg_df):
@@ -847,7 +847,7 @@ def test_48b():
         ['model', 'scen1', 'SDN', 'var', 'unit', 2, 7],
     ], columns=['model', 'scenario', 'region',
                 'variable', 'unit', 2005, 2010],
-    )).data.reset_index(drop=True)
+    )).data
 
     df = IamDataFrame(pd.DataFrame([
         ['model', 'scen', 'R5MAF', 'var', 'unit', 1, 6],
@@ -856,7 +856,7 @@ def test_48b():
                 'variable', 'unit', 2005, 2010],
     ))
     obs = df.map_regions('iso', region_col='r5_region').data
-    obs = obs[obs.region.isin(['SSD', 'SDN'])].reset_index(drop=True)
+    obs = sort_data(obs[obs.region.isin(['SSD', 'SDN'])], df._LONG_IDX)
 
     pd.testing.assert_frame_equal(obs, exp, check_index_type=False)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 from pyam import utils
 
 TEST_VARS = pd.Series(['foo', 'foo|bar', 'foo|bar|baz'])
+TEST_CONCAT_SERIES = pd.Series(['foo', 'bar', 'baz'], index=['f', 'b', 'z'])
 
 
 def test_pattern_match_none():
@@ -145,3 +146,20 @@ def test_find_depth_1_minus():
 def test_find_depth_1_plus():
     obs = utils.find_depth(TEST_VARS, level='1+')
     assert obs == [False, True, True]
+
+
+def test_concat_with_pipe_all():
+    obs = utils.concat_with_pipe(TEST_CONCAT_SERIES)
+    assert obs == 'foo|bar|baz'
+
+
+def test_concat_with_pipe_exclude_none():
+    s = TEST_CONCAT_SERIES.copy()
+    s['b'] = None
+    obs = utils.concat_with_pipe(s)
+    assert obs == 'foo|baz'
+
+
+def test_concat_with_pipe_by_name():
+    obs = utils.concat_with_pipe(TEST_CONCAT_SERIES, ['f', 'z'])
+    assert obs == 'foo|baz'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,3 +170,19 @@ def test_concat_with_pipe_exclude_nan():
 def test_concat_with_pipe_by_name():
     obs = utils.concat_with_pipe(TEST_CONCAT_SERIES, ['f', 'z'])
     assert obs == 'foo|baz'
+
+
+def test_reduce_hierarchy_0():
+    assert utils.reduce_hierarchy('foo|bar|baz', 0) == 'foo'
+
+
+def test_reduce_hierarchy_1():
+    assert utils.reduce_hierarchy('foo|bar|baz', 1) == 'foo|bar'
+
+
+def test_reduce_hierarchy_neg1():
+    assert utils.reduce_hierarchy('foo|bar|baz', -1) == 'foo|bar'
+
+
+def test_reduce_hierarchy_neg2():
+    assert utils.reduce_hierarchy('foo|bar|baz', -2) == 'foo'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -160,6 +160,13 @@ def test_concat_with_pipe_exclude_none():
     assert obs == 'foo|baz'
 
 
+def test_concat_with_pipe_exclude_nan():
+    s = TEST_CONCAT_SERIES.copy()
+    s['b'] = np.nan
+    obs = utils.concat_with_pipe(s)
+    assert obs == 'foo|baz'
+
+
 def test_concat_with_pipe_by_name():
     obs = utils.concat_with_pipe(TEST_CONCAT_SERIES, ['f', 'z'])
     assert obs == 'foo|baz'


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added
- [x] Documentation Added

# Description of PR

Before actually getting to extending the `df_to_pyam()` function with a concat-columns option, I went sideways cleaning up a few things. No major changes, but enough to make a PR now.

 - add two auxiliary functions `concat_with_pipe()` and `reduce_hierarchy()` with a bunch of tests
 - add a check that rows in `data` have to be unique at initialization (with a unit test)
 - add a `sort_data()` function to have consistent column/row ordering at initialization and after `append()`
 - improve the behaviour when calling `concat()` with a string (raises `TypeError` rather that trying to initalize an `IamDataFrame`)
 - add a first unit test for `df_to_pyam()`

The first three items could go into a separate PR directly to the `master` branch, but I figured that they aren't worth the trouble cherrypicking and merging and rebasing.