### PR TITLE
Combination of fastinit approaches

### DIFF
--- a/pyam/core.py
+++ b/pyam/core.py
@@ -28,7 +28,6 @@ from pyam.utils import (
     write_sheet,
     read_file,
     read_pandas,
-    fast_format_data,
     format_data,
     merge_meta,
     find_depth,
@@ -121,7 +120,7 @@ class IamDataFrame(object):
     for those who are not used to the pandas/Python universe.
     """
 
-    def __init__(self, data, meta=None, index=DEFAULT_META_INDEX, fast=False, **kwargs):
+    def __init__(self, data, meta=None, index=DEFAULT_META_INDEX, **kwargs):
         """Initialize an instance of an IamDataFrame"""
         if isinstance(data, IamDataFrame):
             if kwargs:
@@ -134,9 +133,9 @@ class IamDataFrame(object):
             for attr, value in data.__dict__.items():
                 setattr(self, attr, value)
         else:
-            self._init(data, meta, index=index, fast=fast, **kwargs)
+            self._init(data, meta, index=index, **kwargs)
 
-    def _init(self, data, meta=None, index=DEFAULT_META_INDEX, fast=False, **kwargs):
+    def _init(self, data, meta=None, index=DEFAULT_META_INDEX, **kwargs):
         """Process data and set attributes for new instance"""
 
         # pop kwarg for meta_sheet_name (prior to reading data from file)
@@ -160,14 +159,11 @@ class IamDataFrame(object):
             if not data.is_file():
                 raise FileNotFoundError(f"No such file: '{data}'")
             logger.info(f"Reading file {data}")
-            _data = read_file(data, index=index, fast=fast, **kwargs)
+            _data = read_file(data, index=index, **kwargs)
 
         # cast data from pandas
         elif isinstance(data, (pd.DataFrame, pd.Series)):
-            if fast:
-                _data = fast_format_data(data, index=index, **kwargs)
-            else:
-                _data = format_data(data.copy(), index=index, **kwargs)
+            _data = format_data(data, index=index, **kwargs)
 
         # unsupported `data` args
         elif islistable(data):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,12 +73,6 @@ def test_init_from_iamdf(test_df_year):
     assert test_df_year.scenario == ["scen_b", "scen_foo"]
 
 
-def test_init_fast(test_df_year):
-    obs = IamDataFrame(test_df_year, fast=True)
-    exp = IamDataFrame(test_df_year)
-    assert_iamframe_equal(obs, exp)
-
-
 def test_init_from_iamdf_raises(test_df_year):
     # casting an IamDataFrame instance again with extra args fails
     match = "Invalid arguments for initializing from IamDataFrame: {'model': 'foo'}"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -226,11 +226,10 @@ def test_load_meta_empty(test_pd_df):
     assert_iamframe_equal(obs, exp)
 
 
-@pytest.mark.parametrize("fast", [True, False])
-def test_load_ssp_database_downloaded_file(test_pd_df, fast):
+def test_load_ssp_database_downloaded_file(test_pd_df):
     exp = IamDataFrame(test_pd_df).filter(**FILTER_ARGS).as_pandas()
     file = TEST_DATA_DIR / "test_SSP_database_raw_download.xlsx"
-    obs_df = IamDataFrame(file, fast=fast)
+    obs_df = IamDataFrame(file)
     pd.testing.assert_frame_equal(obs_df.as_pandas(), exp)
 
 


### PR DESCRIPTION
Refactoring of the `format_data` function with internal fast-path.

Basically, if one passes a dataframe or series with a multi-index which includes `index` and all required columns
it will avoid reset_indexing it.

@gidden Not sure, how to create those profile pictures. Would be nice to include this variant!

Tries to input into https://github.com/IAMconsortium/pyam/pull/726.


# Please confirm that this PR has done the following:

- [ ] Tests Added
- [ ] Documentation Added
- [ ] Description in RELEASE_NOTES.md Added

## Adding to RELEASE_NOTES.md (remove section after adding to RELEASE_NOTES.md)

Please add a single line in the release notes similar to the following:

```
- (#XX)[http://link-to-pr.com] Added feature which does something
```

# Description of PR

Please describe the changes introduced by this PR.
